### PR TITLE
Make children optional to simplify loaded-checks

### DIFF
--- a/src/Loading.js
+++ b/src/Loading.js
@@ -21,7 +21,7 @@ const Loading = ({ isLoading, errorMessage, children }) => {
 Loading.propTypes = {
     isLoading: PropTypes.bool.isRequired,
     errorMessage: PropTypes.string,
-    children: PropTypes.element.isRequired
+    children: PropTypes.element
 };
 
 export default Loading;


### PR DESCRIPTION
this allows <Loading>{objectToLoad && <ObjectDependentElements/>}</Loading>